### PR TITLE
fix clicky linky

### DIFF
--- a/about.html
+++ b/about.html
@@ -29,6 +29,8 @@
 			min-width: 10%;
 			text-align: center;
   			text-decoration: none;
+			z-index: 100;
+			position: relative;
 		}
 	
 	


### PR DESCRIPTION
top-nav should have z-index:100 and position:relative per https://stackoverflow.com/questions/7245896/link-using-z-index-cant-be-clicked-even-though-its-on-top-in-both-firefox-i